### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/SMPyBandits/PoliciesMultiPlayers/rhoLearn.py
+++ b/SMPyBandits/PoliciesMultiPlayers/rhoLearn.py
@@ -5,7 +5,7 @@
 - But instead of aiming at the best (the 1-st best) arm, player i aims at the rank_i-th best arm,
 - At first, every player has a random rank_i from 1 to M, and when a collision occurs, rank_i is given by a second learning algorithm, playing on arms = ranks from [1, .., M], where M is the number of player.
 - If rankSelection = Uniform, this is like rhoRand, but if it is a smarter policy, it *might* be better! Warning: no theoretical guarantees exist!
-- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://dx.doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
+- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
 
 
 .. note:: This is not fully decentralized: as each child player needs to know the (fixed) number of players.
@@ -52,7 +52,7 @@ except ImportError:
 
 
 #: Should oneRhoLearn players select a (possibly new) rank *at each step* ?
-#: The algorithm P2 from https://dx.doi.org/10.4108/eai.5-9-2016.151647 suggests to do so.
+#: The algorithm P2 from https://doi.org/10.4108/eai.5-9-2016.151647 suggests to do so.
 #: But I found it works better **without** this trick.
 CHANGE_RANK_EACH_STEP = True
 CHANGE_RANK_EACH_STEP = False
@@ -91,7 +91,7 @@ class oneRhoLearn(oneRhoRand):
 
         # First give a reward to the rank selection learning algorithm (== collision avoidance)
         self.rankSelection.getReward(self.rank - 1, 1)
-        # Note: this is NOTHING BUT a heuristic! See equation (13) in https://dx.doi.org/10.4108/eai.5-9-2016.151647
+        # Note: this is NOTHING BUT a heuristic! See equation (13) in https://doi.org/10.4108/eai.5-9-2016.151647
 
         # Then, use the rankSelection algorithm to select a (possibly new) rank
         if self.change_rank_each_step:  # That's new! rhoLearn (can) change its rank at ALL steps!

--- a/SMPyBandits/PoliciesMultiPlayers/rhoLearnEst.py
+++ b/SMPyBandits/PoliciesMultiPlayers/rhoLearnEst.py
@@ -6,7 +6,7 @@ r""" rhoLearnEst: implementation of the multi-player policy from [Distributed Al
 - But instead of aiming at the best (the 1-st best) arm, player i aims at the rank_i-th best arm,
 - At first, every player has a random rank_i from 1 to M, and when a collision occurs, rank_i is given by a second learning algorithm, playing on arms = ranks from [1, .., M], where M is the number of player.
 - If rankSelection = Uniform, this is like rhoRand, but if it is a smarter policy, it *might* be better! Warning: no theoretical guarantees exist!
-- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://dx.doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
+- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
 
 .. note:: This is fully decentralized: each child player does *not* need to know the (fixed) number of players, it will learn to select ranks only in :math:`\{1,\dots,M\}` instead of :math:`\{1,\dots,K\}`.
 

--- a/SMPyBandits/PoliciesMultiPlayers/rhoLearnExp3.py
+++ b/SMPyBandits/PoliciesMultiPlayers/rhoLearnExp3.py
@@ -5,7 +5,7 @@
 - But instead of aiming at the best (the 1-st best) arm, player i aims at the rank_i-th best arm,
 - At first, every player has a random rank_i from 1 to M, and when a collision occurs, rank_i is given by a second learning algorithm, playing on arms = ranks from [1, .., M], where M is the number of player.
 - If rankSelection = Uniform, this is like rhoRand, but if it is a smarter policy (like Exp3 here), it *might* be better! Warning: no theoretical guarantees exist!
-- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://dx.doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
+- Reference: [Proof-of-Concept System for Opportunistic Spectrum Access in Multi-user Decentralized Networks, S.J.Darak, C.Moy, J.Palicot, EAI 2016](https://doi.org/10.4108/eai.5-9-2016.151647), algorithm 2. (for BayesUCB only)
 
 
 .. note:: This is not fully decentralized: as each child player needs to know the (fixed) number of players.
@@ -145,7 +145,7 @@ reward_from_decoupled_feedback = binary_feedback
 
 
 #: Should oneRhoLearnExp3 players select a (possibly new) rank *at each step* ?
-#: The algorithm P2 from https://dx.doi.org/10.4108/eai.5-9-2016.151647 suggests to do so.
+#: The algorithm P2 from https://doi.org/10.4108/eai.5-9-2016.151647 suggests to do so.
 #: But I found it works better *without* this trick.
 CHANGE_RANK_EACH_STEP = True
 CHANGE_RANK_EACH_STEP = False
@@ -189,7 +189,7 @@ class oneRhoLearnExp3(oneRhoRand):
         # First give a reward to the rank selection learning algorithm (== collision avoidance)
         reward_on_rank = self.feedback_function(reward, 0)
         self.rankSelection.getReward(self.rank - 1, reward_on_rank)
-        # Note: this is NOTHING BUT a heuristic! See equation (13) in https://dx.doi.org/10.4108/eai.5-9-2016.151647
+        # Note: this is NOTHING BUT a heuristic! See equation (13) in https://doi.org/10.4108/eai.5-9-2016.151647
 
         # Then, use the rankSelection algorithm to select a (possibly new) rank
         if self.change_rank_each_step:  # That's new! rhoLearnExp3 (can) change its rank at ALL steps!


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all "old" DOI links.

Cheers!


PS: I'm a bit confused by the "write-only" over in [SMPyBandits/SMPyBandits.github.io](https://github.com/SMPyBandits/SMPyBandits.github.io). Is it being auto-generated, or should I send the same PR there as well?