### PR TITLE
Fixes for DUCB and kl-lcb computation

### DIFF
--- a/SMPyBandits/Policies/DiscountedUCB.py
+++ b/SMPyBandits/Policies/DiscountedUCB.py
@@ -74,10 +74,12 @@ class DiscountedUCB(UCBalpha):
         """
         super(DiscountedUCB, self).getReward(arm, reward)
         # FIXED we should multiply by gamma^delta where delta is the number of time steps where we didn't play this arm, +1
-        self.discounted_pulls[arm] = ((self.gamma ** (1 + self.delta_time_steps[arm])) * self.discounted_pulls[arm]) + 1
-        # XXX self.discounted_pulls[arm] += 1  # if we were using N_k(t) and not N_{k,gamma}(t).
+        self.discounted_pulls *= self.gamma
+        self.discounted_rewards *= self.gamma
+        self.discounted_pulls[arm] += 1
         reward = (reward - self.lower) / self.amplitude
-        self.discounted_rewards[arm] = ((self.gamma ** (1 + self.delta_time_steps[arm])) * self.discounted_rewards[arm]) + reward
+        self.discounted_rewards[arm] += reward
+        # XXX self.discounted_pulls[arm] += 1  # if we were using N_k(t) and not N_{k,gamma}(t).
         # Ok and we saw this arm so no delta now
         if self.useRealDiscount:
             self.delta_time_steps += 1  # increase delay for each algorithms

--- a/SMPyBandits/Policies/kullback.py
+++ b/SMPyBandits/Policies/kullback.py
@@ -644,7 +644,7 @@ def kllcb(x, d, kl, lowerbound,
     while _count_iteration < max_iterations and value - l > precision:
         _count_iteration += 1
         m = (value + l) * 0.5
-        if kl(x, m) < d:
+        if kl(x, m) > d:
             l = m
         else:
             value = m


### PR DESCRIPTION
Two bugs I ran into while I was using your lib.

1) DUCB currently does not discount pulls and reward at each round but only when an arm is effectively pulled.  It impacts the computation of the upper confidence bound : when an arm has not been pulled for a long time, its sum of the discounted pulls do not decay. Hence, extra exploration is not forced. 
I am 100% sure that this fix is not equivalent to your implementation (very different result)
I am 99% sure that this fix is the true D-UCB but if you have any doubt we should discuss it. 

2) bug in kl-lcb (wrong copy paste from kl-ucb ?) 