### PR TITLE
Optimized store function by removing repetitions

### DIFF
--- a/SMPyBandits/Environment/Evaluator.py
+++ b/SMPyBandits/Environment/Evaluator.py
@@ -255,7 +255,11 @@ class Evaluator(object):
                 self.maxCumRewards[policyId, envId, :] = np.maximum(self.maxCumRewards[policyId, envId, :], np.cumsum(r.rewards)) if repeatId > 1 else np.cumsum(r.rewards)
             self.bestArmPulls[envId][policyId, :] += np.cumsum(np.in1d(r.choices, r.indexes_bestarm))
             self.pulls[envId][policyId, :] += r.pulls
-            if self.moreAccurate: self.allPulls[envId][policyId, :, :] += np.array([1 * (r.choices == armId) for armId in range(env.nbArms)])  # XXX consumes a lot of zeros but it is not so costly
+            if self.moreAccurate:
+                # Make allPulls by selecting rows of an identity matrix using r.choices
+                # The identity matrix is made with shape (nbArms, nbArms)
+                select_rows = r.choices.reshape(1, -1)
+                self.allPulls[envId][policyId, :, :] += np.transpose(np.identity(self.envs[envId].nbArms, dtype=int)[select_rows][0])
             self.memoryConsumption[envId][policyId, repeatId] = r.memory_consumption
             self.lastPulls[envId][policyId, :, repeatId] = r.pulls
             self.runningTimes[envId][policyId, repeatId] = r.running_time


### PR DESCRIPTION
Recently, I did some numerical experiments with many arms more than 5000 arms, and horizon 100000.

I found that it is extremely slow to repeat using 'for' statement with thousands of arms, in `store` function of SMPyBandits/Environment/Evaluator.py.
Therefore, I optimized that `store` function by removing repetitions.

The optimized code consumes about only half the execution time of the original code!
I compared running times of original code and my optimized code below.


nbArms = 5000, horizon = 50000
original: 124s, optimized: 66s
```
>>> import timeit
>>>
>>> timeit.timeit('''
... import numpy as np
...
... nbArms = 5000
... horizon = 50000
... choices = np.random.randint(0, nbArms, horizon)
...
... np.array([1 * (choices == armId) for armId in range(nbArms)])
... ''', number=50)
124.48019195400002


>>> import timeit
>>>
>>> timeit.timeit('''
... import numpy as np
...
... nbArms = 5000
... horizon = 50000
... choices = np.random.randint(0, nbArms, horizon)
... select_rows = choices.reshape(1, -1)
...
... np.transpose(np.identity(nbArms, dtype=int)[select_rows][0])
... ''', number=50)
65.51110079
```

nbArms = 1000, horizon = 50000
original: 25s, optimized: 10s

nbArms = 5000, horizon = 50000
original: 26s, optimized: 16s

nbArms = 5000, horizon = 50000
original: 0.36s, optimized: 0.04s

Test environment:
MacBook Pro (15-inch, 2017)
2.8 GHz Quad Core Intel Core i7
16GB 2133 MHz LPDDR3